### PR TITLE
Update to be compatible with Pylint 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ cnes-pylint-extension checks the following metrics :
 Available versions :
 - Version 1.0 - compatible pylint 1.5
 - Version 2.0 - compatible pylint 1.6
+- Version 3.0 - compatible pylint 1.7.4

--- a/test/functional/check_docstring_fields.py
+++ b/test/functional/check_docstring_fields.py
@@ -25,7 +25,7 @@ class MyClass(object):  # [missing-type-doc]
         self.par1 = par1
         self.par2 = par2
 
-    def method(self, par3, par4):  # [missing-param-doc, missing-type-doc, missing-docstring-description, missing-returns-doc]
+    def method(self, par3, par4):  # [differing-param-doc, missing-param-doc, differing-type-doc, missing-type-doc, missing-docstring-description, missing-return-doc, missing-return-type-doc]
         """
 
         :param int par1: some param

--- a/test/functional/check_docstring_fields.txt
+++ b/test/functional/check_docstring_fields.txt
@@ -1,10 +1,13 @@
 malformed-docstring-field:1::malformed "date" field in check_docstring_fields docstring
 malformed-docstring-field:1::malformed "version" field in check_docstring_fields docstring
 missing-docstring-field:1::"author" field missing from check_docstring_fields docstring
-missing-param-doc:12:func:"bar, foo" missing or differing in parameter documentation
-missing-type-doc:12:func:"bar, foo" missing or differing in parameter type documentation
-missing-type-doc:17:MyClass:"par2" missing or differing in parameter type documentation
+missing-param-doc:12:func:"bar, foo" missing in parameter documentation
+missing-type-doc:12:func:"bar, foo" missing in parameter type documentation
+missing-type-doc:17:MyClass:"par2" missing in parameter type documentation
+differing-param-doc:28:MyClass.method:"par1" differing in parameter documentation
+differing-type-doc:28:MyClass.method:"par1" differing in parameter type documentation
 missing-docstring-description:28:MyClass.method:description missing in method docstring
-missing-param-doc:28:MyClass.method:"par1, par3" missing or differing in parameter documentation
-missing-returns-doc:28:MyClass.method:Missing return type documentation
-missing-type-doc:28:MyClass.method:"par1, par3" missing or differing in parameter type documentation
+missing-param-doc:28:MyClass.method:"par3" missing in parameter documentation
+missing-return-doc:28:MyClass.method:Missing return documentation
+missing-return-type-doc:28:MyClass.method:Missing return type documentation
+missing-type-doc:28:MyClass.method:"par3" missing in parameter type documentation

--- a/test/functional/use_context_manager.py
+++ b/test/functional/use_context_manager.py
@@ -15,8 +15,8 @@ with lock:
 lock.acquire()  # [use-context-manager]
 lock.release()
 
-#lock = threading.Lock()
-#lock.acquire()  [use-context-manager]
+lock = threading.Lock()
+lock.acquire()  # [use-context-manager]
 
 lock = threading.Semaphore()
 lock.acquire()  # [use-context-manager]


### PR DESCRIPTION
In Pylint 1.7.4 "missing-<...>-doc" errors are only raised on missing documentation
while in 1.6.5 they were also triggered on differing parameters.
This means we now have to specify the expected errors using either
"missing-<...>-doc" or "differing-<...>-doc".