### PR TITLE
Make compatible with Pylint 2.1.1 and Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Available versions :
 - Version 1.0 - compatible pylint 1.5
 - Version 2.0 - compatible pylint 1.6
 - Version 3.0 - compatible pylint 1.7.4
+- Version 4.0 - compatible pylint 2.1.1

--- a/checkers/cnes_checker.py
+++ b/checkers/cnes_checker.py
@@ -27,6 +27,7 @@ from pylint.checkers import BaseChecker, BaseTokenChecker
 from pylint.checkers.utils import check_messages
 from pylint.checkers.raw_metrics import get_type
 from pylint.utils import WarningScope
+import tokenize
 
 
 class DesignChecker(BaseChecker):
@@ -100,7 +101,7 @@ class DesignChecker(BaseChecker):
                 if funcdef.name == 'open':
                     parent = funcdef.parent
                     if (isinstance(parent, astroid.Module)
-                            and parent.name == '__builtin__'):
+                            and parent.name == '_io'):
                         if not isinstance(node.parent, astroid.With):
                             self.add_message('use-context-manager', node=node,
                                              args='opening the file')
@@ -216,6 +217,8 @@ class CommentMetricsChecker(BaseTokenChecker):
         """update stats"""
         i = 0
         tokens = list(tokens)
+        if tokens[0].type == tokenize.ENCODING:
+            i = 1
         tail = None
         while i < len(tokens):
             start_line = tokens[i][2][0]

--- a/test/functional/builtin_name_used.py
+++ b/test/functional/builtin_name_used.py
@@ -3,7 +3,7 @@
 
 class MyClass(object):
     def __init__(self):
-        ((self.file, (self.str, self.something)), plop) = (('test.txt', 'hello'), 'plop')  # [builtin-name-used, builtin-name-used]
+        ((self.str, self.something), plop) = (('test.txt', 'hello'), 'plop')  # [builtin-name-used]
 
     bool = True  # [builtin-name-used]
 

--- a/test/functional/builtin_name_used.txt
+++ b/test/functional/builtin_name_used.txt
@@ -1,4 +1,3 @@
-builtin-name-used:6:MyClass.__init__:file is named after a built-in, consider renaming it
 builtin-name-used:6:MyClass.__init__:str is named after a built-in, consider renaming it
 builtin-name-used:8:MyClass:bool is named after a built-in, consider renaming it
 builtin-name-used:10:MyClass.map:map is named after a built-in, consider renaming it

--- a/test/functional/os_environ_used.py
+++ b/test/functional/os_environ_used.py
@@ -9,7 +9,7 @@ from os import environ as e
 def function1():
     a = os.environ  # [os-environ-used]
 
-print e  # [os-environ-used]
+print(e)  # [os-environ-used]
 env = o.getenv()  # [os-environ-used]
 o.putenv('TOTO', 'titi')  # [os-environ-used]
 sep = o.sep

--- a/test/functional/sys_argv_used.py
+++ b/test/functional/sys_argv_used.py
@@ -9,7 +9,7 @@ from sys import argv as a
 def function1():
     a = s.argv[0]  # [sys-argv-used]
 
-print a  # [sys-argv-used]
+print(a)  # [sys-argv-used]
 
 if len(sys.argv > 1):  # [sys-argv-used]
     param = sys.argv[1]  # [sys-argv-used]


### PR DESCRIPTION
Changes proposed :
- Indicate compatibility in Readme
- When checking calls to the builtin 'open' function without manager we now have to check that the module of the 'open' function is '_io'.
- We remove the 'file' definition and its corresponding 'builtin-name-used' expectation in 'builtin-name used.py' since 'file'is no longer a builtin in Python 3.
- We replace the Python 2 'print' statements by calls to the Python 3 'print' function.
- The Tokenize library used by Pylint now adds an 'ENCODING' token to the start of the token list when tokenizing a file. We have to ignore this token since it isn't representing any line of code.
